### PR TITLE
Init Configuration Profile Support

### DIFF
--- a/buildings.go
+++ b/buildings.go
@@ -21,6 +21,11 @@ type Building struct {
 	Href           *string `json:"href,omitempty"`
 }
 
+type BuildingScope struct {
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
+}
+
 func (c *Client) GetBuildingIdByName(name string) (string, error) {
 	var id string
 	d, err := c.GetBuildings()

--- a/categories.go
+++ b/categories.go
@@ -16,6 +16,11 @@ type Category struct {
 	Href     *string `json:"href,omitempty"`
 }
 
+type GeneralCategory struct {
+	ID   string `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
+}
+
 func (c *Client) GetCategoryIdByName(name string) (string, error) {
 	var id string
 	d, err := c.GetCategories()

--- a/computerConfigurationProfiles.go
+++ b/computerConfigurationProfiles.go
@@ -1,0 +1,167 @@
+package jamf
+
+import (
+	"fmt"
+)
+
+const uriComputerConfigurationProfiles = "/JSSResource/osxconfigurationprofiles"
+
+type ComputerConfigurationProfile struct {
+	General     ComputerConfigurationProfileGeneral     `xml:"general"`
+	Scope       ComputerConfigurationProfileScope       `xml:"scope"`
+	SelfService ComputerConfigurationProfileSelfService `xml:"self_service,omitempty"`
+}
+
+type ComputerConfigurationProfileGeneral struct {
+	ID                 int             `xml:"id,omitempty"`
+	Name               string          `xml:"name"`
+	Description        string          `xml:"description"`
+	Site               Site            `xml:"site"`
+	Category           GeneralCategory `xml:"category,omitempty"`
+	DistributionMethod string          `xml:"distribution_method"`
+	UserRemovable      bool            `xml:"user_removable"`
+	Level              string          `xml:"level"`
+	UUID               string          `xml:"uuid"`
+	RedeployOnUpdate   string          `xml:"redeploy_on_update"`
+	Payload            string          `xml:"payloads"`
+}
+
+type ComputerConfigurationProfileScope struct {
+	AllComputers   bool                                         `xml:"all_computers"`
+	AllUsers       bool                                         `xml:"all_jss_users"`
+	Computers      []ComputerScope                              `xml:"computers>computer,omitempty"`
+	Buildings      []BuildingScope                              `xml:"buildings>building,omitempty"`
+	Departments    []DepartmentScope                            `xml:"departments>department,omitempty"`
+	ComputerGroups []ComputerGroupListResponse                  `xml:"computer_groups>computer_group,omitempty"`
+	JamfUsers      []JamfUserScope                              `xml:"jss_users>jss_user,omitempty"`
+	JamfUserGroups []UserGroupScope                             `xml:"jss_user_groups>jss_user_group,omitempty"`
+	Limitiations   ComputerConfigurationProfileScopeLimitations `xml:"limitations"`
+	Exclusions     ComputerConfigurationProfileScopeExclusions  `xml:"exclusions"`
+}
+
+type ComputerConfigurationProfileScopeLimitations struct {
+	Users           []UserScope           `xml:"users>user,omitempty"`
+	UserGroups      []UserGroupScope      `xml:"user_groups>user_group,omitempty"`
+	NetworkSegments []NetworkSegmentScope `xml:"network_segments>network_segment,omitempty"`
+	IBeacons        []IBeaconScope        `xml:"ibeacons>ibeacon,omitempty"`
+}
+type ComputerConfigurationProfileScopeExclusions struct {
+	Computers       []ComputerScope             `xml:"computers>computer,omitempty"`
+	Buildings       []BuildingScope             `xml:"buildings>building,omitempty"`
+	Departments     []DepartmentScope           `xml:"departments>department,omitempty"`
+	ComputerGroups  []ComputerGroupListResponse `xml:"computer_groups>computer_group,omitempty"`
+	Users           []UserScope                 `xml:"users>user,omitempty"`
+	UserGroups      []UserGroupScope            `xml:"user_groups>user_group,omitempty"`
+	NetworkSegments []NetworkSegmentScope       `xml:"network_segments>network_segment,omitempty"`
+	IBeacons        []IBeaconScope              `xml:"ibeacons>ibeacon,omitempty"`
+	JamfUsers       []JamfUserScope             `xml:"jss_users>jss_user,omitempty"`
+	JamfUserGroups  []UserGroupScope            `xml:"jss_user_groups>jss_user_group,omitempty"`
+}
+
+type ComputerConfigurationProfileSelfService struct {
+	SelfServiceDisplayName      string                `xml:"self_service_display_name,omitempty"`
+	InstallButtonText           string                `xml:"install_button_text,omitempty"`
+	SelfServiceDescription      string                `xml:"self_service_description,omitempty"`
+	ForceUsersToViewDescription bool                  `xml:"force_users_to_view_description,omitempty"`
+	RemovalDisallowed           string                `xml:"security>removal_disallowed,omitempty"`
+	SelfServiceIcon             SelfServiceIcon       `xml:"self_service_icon,omitempty,omitempty"`
+	FeatureOnMainPage           bool                  `xml:"feature_on_main_page,omitempty"`
+	SelfServiceCategories       []SelfServiceCategory `xml:"self_service_categories>category,omitempty,omitempty"`
+}
+
+type ComputerConfigurationProfileListResponse struct {
+	Size    int                                    `xml:"size"`
+	Results []ComputerConfigurationProfileListItem `xml:"os_x_configuration_profile"`
+}
+
+type ComputerConfigurationProfileListItem struct {
+	ID   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+func (c *Client) GetComputerConfigurationProfileIdByName(name string) (int, error) {
+	var id int
+	d, err := c.GetComputerConfigurationProfiles()
+	if err != nil {
+		return -1, err
+	}
+
+	for _, v := range d.Results {
+		if v.Name == name {
+			id = v.ID
+			break
+		}
+	}
+	return id, err
+}
+
+func (c *Client) GetComputerConfigurationProfileByName(name string) (*ComputerConfigurationProfile, error) {
+	id, err := c.GetComputerConfigurationProfileIdByName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetComputerConfigurationProfile(id)
+}
+
+func (c *Client) GetComputerConfigurationProfile(id int) (*ComputerConfigurationProfile, error) {
+	var out *ComputerConfigurationProfile
+	uri := fmt.Sprintf("%s/id/%v", uriComputerConfigurationProfiles, id)
+	err := c.doRequest("GET", uri, nil, &out)
+
+	return out, err
+}
+
+func (c *Client) GetComputerConfigurationProfiles() (*ComputerConfigurationProfileListResponse, error) {
+	out := &ComputerConfigurationProfileListResponse{}
+	err := c.doRequest("GET", uriComputerConfigurationProfiles, nil, out)
+
+	return out, err
+}
+
+func (c *Client) CreateComputerConfigurationProfile(d *ComputerConfigurationProfile) (int, error) {
+
+	// Setting usual defaults
+	if d.General.DistributionMethod == "" {
+		d.General.DistributionMethod = "Install Automatically"
+	}
+	if d.General.Level == "" {
+		d.General.Level = "computer"
+	}
+
+	res := &ComputerConfigurationProfileListItem{}
+	reqBody := &struct {
+		*ComputerConfigurationProfile
+		XMLName struct{} `xml:"os_x_configuration_profile"`
+	}{
+		ComputerConfigurationProfile: d,
+	}
+
+	err := c.doRequest("POST", fmt.Sprintf("%s/id/0", uriComputerConfigurationProfiles), reqBody, res)
+	return res.ID, err
+}
+
+func (c *Client) UpdateComputerConfigurationProfile(d *ComputerConfigurationProfile) (int, error) {
+
+	res := &ComputerConfigurationProfile{}
+	uri := fmt.Sprintf("%s/id/%v", uriComputerConfigurationProfiles, d.General.ID)
+	reqBody := &struct {
+		*ComputerConfigurationProfile
+		XMLName struct{} `xml:"os_x_configuration_profile"`
+	}{
+		ComputerConfigurationProfile: d,
+	}
+
+	err := c.doRequest("PUT", uri, reqBody, res)
+
+	return res.General.ID, err
+}
+
+func (c *Client) DeleteComputerConfigurationProfile(id int) (int, error) {
+
+	profile := &ComputerConfigurationProfile{}
+	uri := fmt.Sprintf("%s/id/%v", uriComputerConfigurationProfiles, id)
+	err := c.doRequest("DELETE", uri, nil, profile)
+
+	return profile.General.ID, err
+}

--- a/computers.go
+++ b/computers.go
@@ -5,3 +5,9 @@ type Computer struct {
 	Name         string `json:"name,omitempty" xml:"name,omitempty"`
 	SerialNumber string `json:"serial_number,omitempty" xml:"serial_number,omitempty"`
 }
+
+type ComputerScope struct {
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
+	UDID string `xml:"udid,omitempty"`
+}

--- a/departments.go
+++ b/departments.go
@@ -15,6 +15,11 @@ type Department struct {
 	Href *string `json:"href,omitempty"`
 }
 
+type DepartmentScope struct {
+	ID   int    `xml:"id,omitempty"`
+	Name string `xml:"name,omitempty"`
+}
+
 func (c *Client) GetDepartmentIdByName(name string) (string, error) {
 	var id string
 	d, err := c.GetDepartments()

--- a/ibeacons.go
+++ b/ibeacons.go
@@ -1,0 +1,6 @@
+package jamf
+
+type IBeaconScope struct {
+	Id   int    `xml:"id"`
+	Name string `xml:"name"`
+}

--- a/networkSegments.go
+++ b/networkSegments.go
@@ -1,0 +1,7 @@
+package jamf
+
+type NetworkSegmentScope struct {
+	ID   int    `xml:"id"`
+	UID  string `xml:"uid,omitempty"`
+	Name int    `xml:"name"`
+}

--- a/policies.go
+++ b/policies.go
@@ -37,17 +37,12 @@ type PolicyGeneral struct {
 	LocationUserOnly           bool                                 `xml:"location_user_only"`
 	TargetDrive                string                               `xml:"target_drive"`
 	Offline                    bool                                 `xml:"offline"`
-	Category                   PolicyGeneralCategory                `xml:"category"`
+	Category                   GeneralCategory                      `xml:"category,omitempty"`
 	DateTimeLimitations        PolicyGeneralDateTimeLimitations     `xml:"date_time_limitations"`
 	NetworkLimitations         PolicyGeneralNetworkLimitations      `xml:"network_limitations"`
 	OverrideDefaultSettings    PolicyGeneralOverrideDefaultSettings `xml:"override_default_settings"`
 	NetworkRequirements        string                               `xml:"network_requirements"`
 	Site                       Site                                 `xml:"site"`
-}
-
-type PolicyGeneralCategory struct {
-	ID   string `xml:"id"`
-	Name string `xml:"name"`
 }
 
 // TODO Get types and test
@@ -81,59 +76,30 @@ type PolicyGeneralOverrideDefaultSettings struct {
 
 type PolicyScope struct {
 	AllComputers   bool                        `xml:"all_computers"`
-	Computers      []ComputerPolicyList        `xml:"computers>computer,omitempty"`
+	Computers      []ComputerScope             `xml:"computers>computer,omitempty"`
 	ComputerGroups []ComputerGroupListResponse `xml:"computer_groups>computer_group,omitempty"`
-	Buildings      []BuildingPolicyList        `xml:"buildings>building,omitempty"`
-	Departments    []DepartmentPolicyList      `xml:"departments>department,omitempty"`
+	Buildings      []BuildingScope             `xml:"buildings>building,omitempty"`
+	Departments    []DepartmentScope           `xml:"departments>department,omitempty"`
 	Exclusions     PolicyScopeExclusions       `xml:"exclusions,omitempty"`
 }
 
-type ComputerPolicyList struct {
-	ID   int    `xml:"id,omitempty"`
-	Name string `xml:"name,omitempty"`
-	UDID string `xml:"udid,omitempty"`
-}
-
-type BuildingPolicyList struct {
-	ID   int    `xml:"id,omitempty"`
-	Name string `xml:"name,omitempty"`
-}
-
-type DepartmentPolicyList struct {
-	ID   int    `xml:"id,omitempty"`
-	Name string `xml:"name,omitempty"`
-}
-
 type PolicySelfService struct {
-	UseForSelfService           bool                        `xml:"use_for_self_service"`
-	SelfServiceDisplayName      string                      `xml:"self_service_display_name"`
-	InstallButtonText           string                      `xml:"install_button_text"`
-	ReinstallButtonText         string                      `xml:"reinstall_button_text"`
-	SelfServiceDescription      string                      `xml:"self_service_description"`
-	ForceUsersToViewDescription bool                        `xml:"force_users_to_view_description"`
-	SelfServiceIcon             PolicySelfServiceIcon       `xml:"self_service_icon,omitempty"`
-	FeatureOnMainPage           bool                        `xml:"feature_on_main_page"`
-	SelfServiceCategories       []PolicySelfServiceCategory `xml:"self_service_categories>category,omitempty"`
-}
-
-type PolicySelfServiceIcon struct {
-	ID       int    `xml:"id,omitempty"`
-	Filename string `xml:"filename,omitempty"`
-	URI      string `xml:"uri,omitempty"`
-}
-
-type PolicySelfServiceCategory struct {
-	ID        int    `xml:"id,omitempty"`
-	Name      string `xml:"name,omitempty"`
-	DisplayIn bool   `xml:"display_in,omitempty"`
-	FeatureIn bool   `xml:"feature_in,omitempty"`
+	UseForSelfService           bool                  `xml:"use_for_self_service"`
+	SelfServiceDisplayName      string                `xml:"self_service_display_name"`
+	InstallButtonText           string                `xml:"install_button_text"`
+	ReinstallButtonText         string                `xml:"reinstall_button_text"`
+	SelfServiceDescription      string                `xml:"self_service_description"`
+	ForceUsersToViewDescription bool                  `xml:"force_users_to_view_description"`
+	SelfServiceIcon             SelfServiceIcon       `xml:"self_service_icon,omitempty"`
+	FeatureOnMainPage           bool                  `xml:"feature_on_main_page"`
+	SelfServiceCategories       []SelfServiceCategory `xml:"self_service_categories>category,omitempty"`
 }
 
 type PolicyScopeExclusions struct {
-	Computers      []ComputerPolicyList        `xml:"computers>computer,omitempty"`
+	Computers      []ComputerScope             `xml:"computers>computer,omitempty"`
 	ComputerGroups []ComputerGroupListResponse `xml:"computer_groups>computer_group,omitempty"`
-	Buildings      []BuildingPolicyList        `xml:"buildings>building,omitempty"`
-	Departments    []DepartmentPolicyList      `xml:"departments>department,omitempty"`
+	Buildings      []BuildingScope             `xml:"buildings>building,omitempty"`
+	Departments    []DepartmentScope           `xml:"departments>department,omitempty"`
 }
 
 type PolicyPackageConfiguration struct {

--- a/sharedModels.go
+++ b/sharedModels.go
@@ -1,0 +1,14 @@
+package jamf
+
+type SelfServiceIcon struct {
+	ID       int    `xml:"id,omitempty"`
+	Filename string `xml:"filename,omitempty"`
+	URI      string `xml:"uri,omitempty"`
+}
+
+type SelfServiceCategory struct {
+	ID        int    `xml:"id,omitempty"`
+	Name      string `xml:"name,omitempty"`
+	DisplayIn bool   `xml:"display_in,omitempty"`
+	FeatureIn bool   `xml:"feature_in,omitempty"`
+}

--- a/userGroups.go
+++ b/userGroups.go
@@ -1,0 +1,6 @@
+package jamf
+
+type UserGroupScope struct {
+	Id   int    `xml:"id"`
+	Name string `xml:"name"`
+}

--- a/users.go
+++ b/users.go
@@ -1,0 +1,10 @@
+package jamf
+
+type UserScope struct {
+	Id   int    `xml:"id"`
+	Name string `xml:"name"`
+}
+
+type JamfUserScope struct {
+	Name string `xml:"name"`
+}


### PR DESCRIPTION
**Change Log**

* Init Configuration profile Support
* Changed the Policy category to be optional instead of required using the empty state
* Generalized some of the Classic API scoping structures as they're multiuse