### PR TITLE
Bearer auth default for all endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tmp/
 
 ### .gitkeep ###
 !.gitkeep
+
+### IDE Settings ###
+.vscode/

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/bradfitz/slice v0.0.0-20180809154707-2b758aa73013
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/bradfitz/slice v0.0.0-20180809154707-2b758aa73013 h1:/P9/RL0xgWE+ehnC
 github.com/bradfitz/slice v0.0.0-20180809154707-2b758aa73013/go.mod h1:pccXHIvs3TV/TUqSNyEvF99sxjX2r4FFRIyw6TZY9+w=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
* Migrating from the [deprecated](https://developer.jamf.com/jamf-pro/reference/post_auth-tokens) `/uapi/auth/tokens` endpoint to the `/api/v1/auth/token` endpoint
* Setting Bearer auth to be the default authentication mechanism for the classic API. This avoids issues with the planned [Bearer Token Authentication migration](https://developer.jamf.com/jamf-pro/docs/classic-api-authentication-changes#bearer-token-authentication) planned for later in the year. 
  * Must be running Jamf 10.35.0 to function with this change
*  Implemented Bearer Token Expiration checks to ensure long term clients maintain functionality