### PR TITLE
Fix a recursion bug on token expiration

### DIFF
--- a/client.go
+++ b/client.go
@@ -56,6 +56,8 @@ func (c *Client) refreshAuthToken() error {
 		}
 	}
 
+	c.token = nil
+
 	var out *responseAuthToken
 	if err := c.doRequest("POST", uriAuthToken, nil, nil, &out); err != nil {
 		return err


### PR DESCRIPTION
Clear the token to use basic auth on refresh request