### PR TITLE
Adds API Client Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yohan460/go-jamf-api
+module github.com/jc0b/go-jamf-api
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
-module github.com/jc0b/go-jamf-api
+module github.com/yohan460/go-jamf-api
 
 go 1.17
 
 require (
 	github.com/bradfitz/slice v0.0.0-20180809154707-2b758aa73013
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/google/go-querystring v1.1.0
 	github.com/pkg/errors v0.9.1
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 )

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,10 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=


### PR DESCRIPTION
This PR adds support for API Clients, as introduced in [Jamf 10.49](https://learn.jamf.com/bundle/jamf-pro-documentation-10.49.0/page/API_Roles_and_Clients.html).

I've tested this with a few API endpoints on a Jamf Pro 11 beta instance, and can confirm that the output matches what you'd expect when using the older authentication method.

(This is a new PR, as I moved the new feature to a branch on my own fork)