### PR TITLE
Options between Oauth and Basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,38 @@
 # Jamf API in Go
 
-## Install
+Mostly implemented Golang library for the [Jamf Pro API](https://developer.jamf.com/jamf-pro/docs/jamf-pro-api-overview).
 
-```go
-import "github.com/yohan460/go-jamf-api"
+The Classic API support is written manually, UAPI support is written programmatically using the [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) based upon the publicly available swagger docs.
+
+## Classic API Usage
+
+Example Code
+
+```golang
+package main
+
+import (
+	"fmt"
+	"time"
+    "log"
+
+	"github.com/yohan460/go-jamf-api"
+)
+
+func main() {
+	url := "https://example.jamfcloud.com"
+	client, err := jamf.NewClient(
+        url,
+        jamf.WithOAuth("client-id", "client-secret"),
+    )
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Use the client to make requests to the Jamf API
+}
 ```
 
-## Usage
+## UAPI Usage
 
-sample code: [examples](examples)
-
-
-## Get auth token in curl
-```shell
-$ curl -u username:password -X POST "https://xxxxx.jamfcloud.com/uapi/auth/tokens"
-$ token=xxxxx
-$ curl -X GET -H "Content-Type: application/json" -H "Authorization: Bearer $token" "https://xxxxx.jamfcloud.com/uapi/v1/departments"
-```
+See [Usage docs](api/README.md)

--- a/client.go
+++ b/client.go
@@ -42,35 +42,57 @@ type FormOptions struct {
 	GrantType    string `url:"grant_type"`
 }
 
-// NewClient ... returns a new jamf.Client which can be used to access the API
-func NewClient(username, password, url string) (*Client, error) {
-	c := &Client{
-		username:         username,
-		password:         password,
-		url:              url,
-		token:            nil,
-		HttpClient:       http.DefaultClient,
-		HttpRetryTimeout: 60 * time.Second,
-		ExtraHeader:      make(map[string]string),
-	}
+type Option func(*Client)
 
-	if err := c.refreshAuthToken(); err != nil {
-		return c, errors.Wrap(err, "Error getting bearer auth token")
+// WithHttpClient sets the http client to use for requests
+func WithHttpClient(client *http.Client) Option {
+	return func(c *Client) {
+		c.HttpClient = client
 	}
-
-	return c, nil
 }
 
-// NewOAuthClient ... returns a new jamf.Client which can be used to access the API using the new bearer tokens
-func NewOAuthClient(clientId, clientSecret, url string) (*Client, error) {
+// WithHttpRetryTimeout sets the timeout for retrying requests
+func WithHttpRetryTimeout(timeout time.Duration) Option {
+	return func(c *Client) {
+		c.HttpRetryTimeout = timeout
+	}
+}
+
+// WithExtraHeader sets the extra headers to use for requests
+func WithExtraHeader(header map[string]string) Option {
+	return func(c *Client) {
+		c.ExtraHeader = header
+	}
+}
+
+// WithOAuth sets the client ID and Secret to use OAuth for authentication
+func WithOAuth(clientId, clientSecret string) Option {
+	return func(c *Client) {
+		c.clientId = clientId
+		c.clientSecret = clientSecret
+	}
+}
+
+// WithBasicAuth sets the username and password to use Basic Auth for authentication
+func WithBasicAuth(username, password string) Option {
+	return func(c *Client) {
+		c.username = username
+		c.password = password
+	}
+}
+
+// NewClient ... returns a new jamf.Client which can be used to access the API
+func NewClient(url string, options ...Option) (*Client, error) {
 	c := &Client{
-		clientId:         clientId,
-		clientSecret:     clientSecret,
 		url:              url,
 		token:            nil,
 		HttpClient:       http.DefaultClient,
 		HttpRetryTimeout: 60 * time.Second,
 		ExtraHeader:      make(map[string]string),
+	}
+
+	for _, option := range options {
+		option(c)
 	}
 
 	if err := c.refreshAuthToken(); err != nil {

--- a/request.go
+++ b/request.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/google/go-querystring/query"
 
 	"github.com/cenkalti/backoff"
 )
@@ -76,7 +76,7 @@ func (c *Client) DoRequest(method, api string, reqbody interface{}, params *url.
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -85,7 +85,7 @@ func (c *Client) DoRequest(method, api string, reqbody interface{}, params *url.
 		return newError(resp.StatusCode, api, out)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (c *Client) doRequestWithRetries(req *http.Request) (*http.Response, error)
 	bo.MaxElapsedTime = c.HttpRetryTimeout
 
 	if req.Body != nil {
-		body, err = ioutil.ReadAll(req.Body)
+		body, err = io.ReadAll(req.Body)
 		if err != nil {
 			return resp, err
 		}
@@ -129,7 +129,7 @@ func (c *Client) doRequestWithRetries(req *http.Request) (*http.Response, error)
 
 	boReq := func() error {
 		if body != nil {
-			req.Body = ioutil.NopCloser(bytes.NewReader(body))
+			req.Body = io.NopCloser(bytes.NewReader(body))
 		}
 
 		resp, err = c.HttpClient.Do(req)


### PR DESCRIPTION
* Enable multiple options when setting up a new API client
  * Enables configuration of OAuth or Basic (Bearer) auth support
  * Enables configurability of the HTTP client and Retry Timeout duration
  * Enables configurability of the additional headers
* Updated the ReadMe to have updated information and some example code
* Replaced deprecated `ioutil` package