### PR TITLE
Implement WithJsonMarshalFunc which allow us to use own Marshal function for JSON

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,6 +22,9 @@ type Client struct {
 	HttpClient       *http.Client
 	HttpRetryTimeout time.Duration
 
+	// Store custom JSON Unmarshal function
+	jsonMarshalFunc JsonMarshalFunc
+
 	// Option to specify extra headers like User-Agent
 	ExtraHeader map[string]string
 }
@@ -42,7 +45,18 @@ type FormOptions struct {
 	GrantType    string `url:"grant_type"`
 }
 
+type JsonMarshalFunc func(v any) ([]byte, error)
+
 type Option func(*Client)
+
+// WithJsonMarshalFunc allow override (encoding/json) json.Marshal function with own implementation
+// while keep original function signature.
+func WithJsonMarshalFunc(f JsonMarshalFunc) Option {
+	return func(c *Client) {
+		c.jsonMarshalFunc = f
+
+	}
+}
 
 // WithHttpClient sets the http client to use for requests
 func WithHttpClient(client *http.Client) Option {

--- a/request.go
+++ b/request.go
@@ -177,9 +177,18 @@ func (c *Client) createRequest(method, api string, params *url.Values, reqbody i
 			}
 			bodyReader = strings.NewReader(b.Encode())
 		} else {
-			b, err := json.Marshal(reqbody)
-			if err != nil {
-				return nil, err
+			var b []byte
+			var err error
+			if c.jsonMarshalFunc == nil {
+				b, err = json.Marshal(reqbody)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				b, err = c.jsonMarshalFunc(reqbody)
+				if err != nil {
+					return nil, err
+				}
 			}
 			bodyReader = bytes.NewReader(b)
 		}


### PR DESCRIPTION
Related to: https://github.com/Yohan460/go-jamf-api/issues/18
As short example of usage:
```
.....
myfunc := func(v any) ([]byte, error) {
		byte, err := MyMarshal(v) // Own implementation or another package
		return byte, err
	}
......
mycomp := jamf.ComputerInventory{
		General: &jamf.ComputerInventoryDataSubsetGeneral{
			Name: "TEST123",
		},
	}
....
client, err := jamf.NewClient(....,
	jamf.WithJsonMarshalFunc(myfunc),
)
....
compinv, err := client.UpdateComputerInventoryDetailByID("1", mycomp)
```